### PR TITLE
fix(android): avoid duplicate jni; add r8 keeps

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,9 @@ android {
         abiFilters (*reactNativeArchitectures())
       }
     }
+
+    // Ship ProGuard/R8 consumer rules so apps don't need manual keeps
+    consumerProguardFiles "consumer-rules.pro"
   }
 
   externalNativeBuild {
@@ -40,13 +43,36 @@ android {
     }
   }
 
-  // Do not exclude RN/Hermes JNI libs from the library AAR —
-  // let the app control final packaging to avoid missing/duplicate symbols.
+  // Prevent bundling RN core JNI libs into this AAR to avoid duplicates
+  // in consuming apps (e.g., libjsi.so, libreactnative.so). These are
+  // provided by React Native itself and should not be packaged here.
   packagingOptions {
+    // Keep META-INF cleanup
     excludes = [
             "META-INF",
             "META-INF/**"
     ]
+
+    // Exclude transitive JNI libs that RN/app provides
+    // Support both legacy and new AGP DSLs
+    if (hasProperty('jniLibs')) {
+      jniLibs {
+        excludes += [
+                "**/libjsi.so",
+                "**/libreactnative.so",
+                "**/libfbjni.so",
+                "**/libc++_shared.so",
+                "**/libNitroModules.so"
+        ]
+      }
+    } else {
+      // Fallback for older AGP versions
+      exclude("**/libjsi.so")
+      exclude("**/libreactnative.so")
+      exclude("**/libfbjni.so")
+      exclude("**/libc++_shared.so")
+      exclude("**/libNitroModules.so")
+    }
   }
 
   buildFeatures {

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,8 @@
+-keep class com.margelo.nitro.sound.** { *; }
+
+# HybridObject-based classes are created via reflection; don't shrink/obfuscate
+-keep class * implements com.margelo.nitro.HybridObject { *; }
+-keepclassmembers class * implements com.margelo.nitro.HybridObject { *; }
+
+# Silence warnings for nitro internals
+-dontwarn com.margelo.nitro.**


### PR DESCRIPTION
- fix #710: exclude rn core jni libs from aar to prevent duplicate merge errors\n- fix #711: add consumer r8 keep rules for HybridObjects to avoid release crashes\n\nverified example app builds in debug and release; merged libs include only libNitroSound.so